### PR TITLE
Feature: Queue SolrConfigureJob with changes to search synonym/s

### DIFF
--- a/src/Admins/SearchAdmin.php
+++ b/src/Admins/SearchAdmin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * class SearchAdmin|Firesphere\SolrSearch\Admins\SearchAdmin Base admin for Synonyms, logs and dirty classes
  *
@@ -15,6 +16,7 @@ use Firesphere\SolrSearch\Models\DirtyClass;
 use Firesphere\SolrSearch\Models\SearchSynonym;
 use Firesphere\SolrSearch\Models\SolrLog;
 use SilverStripe\Admin\ModelAdmin;
+use SilverStripe\Forms\LiteralField;
 use SilverStripe\View\Requirements;
 
 /**
@@ -58,6 +60,29 @@ class SearchAdmin extends ModelAdmin
         parent::init();
 
         Requirements::css('signify-nz/silverstripe-solr-search:client/dist/main.css');
+    }
+
+    /**
+     * Add help text above gridfield in search synonyms admin tab.
+     *
+     * @param int $id
+     * @param FieldList $fields
+     * @return Form
+     */
+    public function getEditForm($id = null, $fields = null)
+    {
+        $form = parent::getEditForm($id, $fields);
+
+        $helpText = LiteralField::create(
+            'SearchSynonymHelpText',
+            '<p style="padding-bottom: 1rem;">To have any changes reflected in the search, the SolrConfigureJob needs to be executed.
+            This job is automatically added to the queue when creating, updating, or removing a synonym,
+            and will display in search after the job queue is processed.</p>'
+        );
+
+        $form->Fields()->insertBefore('Firesphere-SolrSearch-Models-SearchSynonym', $helpText);
+
+        return $form;
     }
 
     protected function getManagedModelTabs()

--- a/src/Admins/SearchAdmin.php
+++ b/src/Admins/SearchAdmin.php
@@ -76,8 +76,8 @@ class SearchAdmin extends ModelAdmin
         $helpText = LiteralField::create(
             'SearchSynonymHelpText',
             '<p style="padding-bottom: 1rem;">To have any changes reflected in the search, the SolrConfigureJob needs to be executed.
-            This job is automatically added to the queue when creating, updating, or removing a synonym,
-            and will display in search after the job queue is processed.</p>'
+            This job is automatically added to the queue when creating, updating, or removing a synonym.
+            Changes will display in search after the job queue is processed.</p>'
         );
 
         $form->Fields()->insertBefore('Firesphere-SolrSearch-Models-SearchSynonym', $helpText);


### PR DESCRIPTION
Features:

- SolrConfigureJob gets added to the job queue when search synonyms are created, updated, or deleted.
- Help text is displayed above the search synonyms gridfield in the search admin, which explains the solr configure behaviour to the user.

Unit tests have not been run or updated due to issue outlined in #5.