### PR TITLE
Feat/sigimm 30  improve field analyzers

### DIFF
--- a/Solr/4/extras/solrconfig.xml
+++ b/Solr/4/extras/solrconfig.xml
@@ -1257,7 +1257,7 @@
 
         <!-- a spellchecker built from a field of the main index -->
         <lst name="spellchecker">
-            <str name="name">default</str>
+            <str name="name">_spellcheck</str>
             <str name="field">_text</str>
             <str name="classname">solr.DirectSolrSpellChecker</str>
             <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
@@ -1281,7 +1281,7 @@
 
         <!-- Custom spellcheck dictionary limited to an optional _spellcheckText field -->
         <lst name="spellchecker">
-            <str name="name">_spellcheck</str>
+            <str name="name">default</str>
             <str name="field">_spellcheckText</str>
             <str name="classname">solr.DirectSolrSpellChecker</str>
             <!-- the spellcheck distance measure used, the default is the internal levenshtein -->

--- a/Solr/4/templates/schema.ss
+++ b/Solr/4/templates/schema.ss
@@ -61,7 +61,7 @@
         <field name="ViewStatus" type="string" indexed="true" stored="true" required="true" multiValued="true"/>
         <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
         <% loop $CopyFields %>
-            <field name="$Field" type="htmltext" indexed="true" stored="true" multiValued="true"/>
+            <field name="$Field" type="$Type" indexed="true" stored="true" multiValued="true"/>
         <% end_loop %>
         <% loop $FulltextFieldDefinitions %>
             <field name="$Field" type="$Type" indexed="true" stored="$Stored" multiValued="$MultiValued"/>

--- a/Solr/4/templates/types.ss
+++ b/Solr/4/templates/types.ss
@@ -120,7 +120,7 @@
     -->
 <fieldType name="text" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
     <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <!-- in this example, we will only use synonyms at query time
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         -->
@@ -139,7 +139,7 @@
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
     </analyzer>
     <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory"/>
         <filter class="solr.StopFilterFactory"
@@ -159,7 +159,7 @@
 <fieldType name="htmltext" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
     <analyzer type="index">
         <charFilter class="solr.HTMLStripCharFilterFactory"/>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true"/>
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
@@ -167,7 +167,7 @@
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
     </analyzer>
     <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true"/>
@@ -223,14 +223,14 @@
 <!-- A general unstemmed text field - good if one does not know the language of the field -->
 <fieldType name="textgen" class="solr.TextField" positionIncrementGap="100">
     <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true"/>
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
                 catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
     </analyzer>
     <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"

--- a/Solr/5/extras/solrconfig.xml
+++ b/Solr/5/extras/solrconfig.xml
@@ -1270,7 +1270,7 @@
 
         <!-- a spellchecker built from a field of the main index -->
         <lst name="spellchecker">
-            <str name="name">default</str>
+            <str name="name">_spellcheck</str>
             <str name="field">_text</str>
             <str name="classname">solr.DirectSolrSpellChecker</str>
             <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
@@ -1294,7 +1294,7 @@
 
         <!-- Custom spellcheck dictionary limited to an optional _spellcheckText field -->
         <lst name="spellchecker">
-            <str name="name">_spellcheck</str>
+            <str name="name">default</str>
             <str name="field">_spellcheckText</str>
             <str name="classname">solr.DirectSolrSpellChecker</str>
             <!-- the spellcheck distance measure used, the default is the internal levenshtein -->

--- a/Solr/5/templates/schema.ss
+++ b/Solr/5/templates/schema.ss
@@ -60,7 +60,7 @@
         <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
         <!-- Copyfields -->
         <% loop $CopyFields %>
-            <field name="$Field" type="stemfield" indexed="true" stored="true" multiValued="true"/>
+            <field name="$Field" type="$Type" indexed="true" stored="true" multiValued="true"/>
         <% end_loop %>
         <!-- End Copyfields -->
         <!-- Fulltext fields -->

--- a/Solr/5/templates/types.ss
+++ b/Solr/5/templates/types.ss
@@ -213,7 +213,6 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.LengthFilterFactory" min="4" max="20"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="solr.SnowballPorterFilterFactory"/>
     </analyzer>
 </fieldType>
 
@@ -226,7 +225,6 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.LengthFilterFactory" min="4" max="20"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="solr.SnowballPorterFilterFactory"/>
     </analyzer>
 </fieldType>
 

--- a/Solr/5/templates/types.ss
+++ b/Solr/5/templates/types.ss
@@ -151,10 +151,12 @@
     <analyzer type="index">
         <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
     </analyzer>
     <analyzer type="query">
         <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
     </analyzer>
 </fieldType>

--- a/Solr/5/templates/types.ss
+++ b/Solr/5/templates/types.ss
@@ -120,7 +120,7 @@
     -->
 <fieldType name="text" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
     <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory"/>
         <filter class="solr.StopFilterFactory"
@@ -136,7 +136,7 @@
         <filter class="solr.SnowballPorterFilterFactory"/>
     </analyzer>
     <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory"
@@ -149,11 +149,11 @@
 </fieldType>
 <fieldType name="stemfield" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
     <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
     </analyzer>
     <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
     </analyzer>
@@ -161,7 +161,7 @@
 <!-- A copy of text that has the HTMLStripCharFilterFactory as the first index analyzer, so that html can be provided -->
 <fieldType name="htmltext" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
     <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <charFilter class="solr.HTMLStripCharFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
@@ -171,7 +171,7 @@
         <filter class="solr.SnowballPorterFilterFactory"/>
     </analyzer>
     <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
@@ -231,7 +231,7 @@
 <!-- A general unstemmed text field - good if one does not know the language of the field -->
 <fieldType name="textgen" class="solr.TextField" positionIncrementGap="100">
     <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
@@ -239,7 +239,7 @@
         <filter class="solr.SnowballPorterFilterFactory"/>
     </analyzer>
     <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"

--- a/Solr/5/templates/types.ss
+++ b/Solr/5/templates/types.ss
@@ -119,24 +119,6 @@
     NOTE: autoGeneratePhraseQueries="true" tends to not work well for non whitespace delimited languages.
     -->
 <fieldType name="text" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
-    <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
-        <!-- Case insensitive stop word removal.
-          add enablePositionIncrements=true in both the index and query
-          analyzers to leave a 'gap' for more accurate phrase queries.
-        -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="stopwords.txt"
-
-        />
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
-                catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-    </analyzer>
     <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -156,6 +138,13 @@
     <analyzer type="index">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="stopwords.txt"
+        />
+        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1"
+                catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
     </analyzer>
 </fieldType>
 <fieldType name="stemfield" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">

--- a/Solr/7/extras/solrconfig.xml
+++ b/Solr/7/extras/solrconfig.xml
@@ -1270,7 +1270,7 @@
 
         <!-- a spellchecker built from a field of the main index -->
         <lst name="spellchecker">
-            <str name="name">default</str>
+            <str name="name">_spellcheck</str>
             <str name="field">_text</str>
             <str name="classname">solr.DirectSolrSpellChecker</str>
             <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
@@ -1294,7 +1294,7 @@
 
         <!-- Custom spellcheck dictionary limited to an optional _spellcheckText field -->
         <lst name="spellchecker">
-            <str name="name">_spellcheck</str>
+            <str name="name">default</str>
             <str name="field">_spellcheckText</str>
             <str name="classname">solr.DirectSolrSpellChecker</str>
             <!-- the spellcheck distance measure used, the default is the internal levenshtein -->

--- a/Solr/7/templates/schema.ss
+++ b/Solr/7/templates/schema.ss
@@ -60,7 +60,7 @@
         <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
         <!-- Copyfields -->
         <% loop $CopyFields %>
-            <field name="$Field" type="stemfield" indexed="true" stored="true" multiValued="true"/>
+            <field name="$Field" type="$Type" indexed="true" stored="true" multiValued="true"/>
         <% end_loop %>
         <!-- End Copyfields -->
         <!-- Fulltext fields -->

--- a/Solr/7/templates/types.ss
+++ b/Solr/7/templates/types.ss
@@ -157,6 +157,7 @@
         <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
@@ -165,6 +166,7 @@
         <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
     </analyzer>

--- a/Solr/7/templates/types.ss
+++ b/Solr/7/templates/types.ss
@@ -234,7 +234,6 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.LengthFilterFactory" min="4" max="20"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="solr.SnowballPorterFilterFactory"/>
     </analyzer>
 </fieldType>
 
@@ -248,7 +247,6 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.LengthFilterFactory" min="4" max="20"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="solr.SnowballPorterFilterFactory"/>
     </analyzer>
 </fieldType>
 

--- a/Solr/7/templates/types.ss
+++ b/Solr/7/templates/types.ss
@@ -142,14 +142,14 @@
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="stopwords.txt"
         />
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
-                catenateWords="1"
-                catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
     </analyzer>
 </fieldType>
 <fieldType name="stemfield" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">

--- a/Solr/7/templates/types.ss
+++ b/Solr/7/templates/types.ss
@@ -119,26 +119,6 @@
     NOTE: autoGeneratePhraseQueries="true" tends to not work well for non whitespace delimited languages.
     -->
 <fieldType name="text" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
-    <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
-        <!-- Case insensitive stop word removal.
-          add enablePositionIncrements=true in both the index and query
-          analyzers to leave a 'gap' for more accurate phrase queries.
-        -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="stopwords.txt"
-
-        />
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
-                catenateWords="1"
-                catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
-    </analyzer>
     <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -163,6 +143,13 @@
         <filter class="solr.SnowballPorterFilterFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
+        <filter class="solr.StopFilterFactory"
+                ignoreCase="true"
+                words="stopwords.txt"
+        />
+        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
     </analyzer>
 </fieldType>
 <fieldType name="stemfield" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">

--- a/Solr/7/templates/types.ss
+++ b/Solr/7/templates/types.ss
@@ -120,7 +120,7 @@
     -->
 <fieldType name="text" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
     <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory"/>
@@ -138,7 +138,7 @@
         <filter class="solr.SnowballPorterFilterFactory"/>
     </analyzer>
     <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
@@ -154,7 +154,7 @@
 </fieldType>
 <fieldType name="stemfield" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
     <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
@@ -162,7 +162,7 @@
         <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
     </analyzer>
     <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
@@ -172,7 +172,7 @@
 <!-- A copy of text that has the HTMLStripCharFilterFactory as the first index analyzer, so that html can be provided -->
 <fieldType name="htmltext" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
     <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <charFilter class="solr.HTMLStripCharFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
@@ -186,7 +186,7 @@
         <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
     </analyzer>
     <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory"/>
@@ -253,7 +253,7 @@
 <!-- A general unstemmed text field - good if one does not know the language of the field -->
 <fieldType name="textgen" class="solr.TextField" positionIncrementGap="100">
     <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
@@ -265,7 +265,7 @@
         <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
     </analyzer>
     <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
         <filter class="solr.StopFilterFactory"

--- a/Solr/9/extras/solrconfig.xml
+++ b/Solr/9/extras/solrconfig.xml
@@ -1270,7 +1270,7 @@
 
         <!-- a spellchecker built from a field of the main index -->
         <lst name="spellchecker">
-            <str name="name">default</str>
+            <str name="name">_spellcheck</str>
             <str name="field">_text</str>
             <str name="classname">solr.DirectSolrSpellChecker</str>
             <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
@@ -1294,7 +1294,7 @@
 
         <!-- Custom spellcheck dictionary limited to an optional _spellcheckText field -->
         <lst name="spellchecker">
-            <str name="name">_spellcheck</str>
+            <str name="name">default</str>
             <str name="field">_spellcheckText</str>
             <str name="classname">solr.DirectSolrSpellChecker</str>
             <!-- the spellcheck distance measure used, the default is the internal levenshtein -->

--- a/Solr/9/templates/schema.ss
+++ b/Solr/9/templates/schema.ss
@@ -61,7 +61,7 @@
         <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
         <!-- Copyfields -->
         <% loop $CopyFields %>
-            <field name="$Field" type="stemfield" indexed="true" stored="true" multiValued="true"/>
+            <field name="$Field" type="$Type" indexed="true" stored="true" multiValued="true"/>
         <% end_loop %>
         <!-- End Copyfields -->
         <!-- Fulltext fields -->

--- a/Solr/9/templates/types.ss
+++ b/Solr/9/templates/types.ss
@@ -157,6 +157,7 @@
         <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
@@ -165,6 +166,7 @@
         <tokenizer class="solr.ClassicTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
     </analyzer>

--- a/Solr/9/templates/types.ss
+++ b/Solr/9/templates/types.ss
@@ -234,7 +234,6 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.LengthFilterFactory" min="4" max="20"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="solr.SnowballPorterFilterFactory"/>
     </analyzer>
 </fieldType>
 
@@ -248,7 +247,6 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.LengthFilterFactory" min="4" max="20"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="solr.SnowballPorterFilterFactory"/>
     </analyzer>
 </fieldType>
 

--- a/docs/03-Set-up-and-Configuration.md
+++ b/docs/03-Set-up-and-Configuration.md
@@ -161,10 +161,21 @@ Available methods are:
 | addFilterField | Add fields to use for filtering | No | `$this->addFilterField('ID');` |
 | addBoostedField | Fields to boost by on Query time | No | `$this->addBoostedField('Title', ([]/2), 2);`<sup>2</sup> |
 | addSortField | Field to sort by | No | `$this->addSortField('Created');` |
-| addCopyField | Add a special copy field, besides the default _text | No | `$this->addCopyField('myCopy', ['Fields', 'To', 'Copy']);` |
+| addCopyField | Add a special copy field, besides the default _text | No | `$this->addCopyField('myCopy', ['Fields', 'To', 'Copy']);` <br />See [below](#changing-the-copy-field-type) to change the field type |
 | addStoredField | Add a field to be stored specifically | No | `$this->addStoredField('LastEdited');` |
 | addFacetField | Field to build faceting on | No | `$this->addFacetField(SiteTree::class, ['BaseClass' => SiteTree::class, 'Title' => 'FacetObject', 'Field' => 'FacetObjectID']);` |
- 
+
+#### Changing the copy field type
+
+A copy field type will default to using stemfield (htmltext if using Solr 4) if not set. To change the field type for a CopyField, the `'type'` can be set as an `$option` in `addCopyField` like so:
+
+```php
+$this->addCopyField('myCopy', ['Fields', 'To', 'Copy', 'type' => 'FieldType']);
+```
+Example:
+```php
+$this->addCopyField('myCopy', ['Title', 'Content', 'type' => 'text']);
+```
 
 ### Using YML
 

--- a/docs/05-Spellcheck.md
+++ b/docs/05-Spellcheck.md
@@ -5,6 +5,14 @@
 Spellchecking is enabled by default, and can be disabled
 on query time, by setting `$query->setSpellcheck(false);`
 
+The default behaviour of spellcheck does not include stemming.
+This can be disabled in the config like so:
+
+```yaml
+Firesphere\SolrSearch\Indexes\BaseIndex:
+    include_dedicated_spellcheck_field: false
+```
+
 Spellchecking is carried over to the search result returned.
 
 To access the spellchecks, the following methods can be used:
@@ -16,18 +24,16 @@ if the query is "hesp me", the word based spellcheck will return a list
 of words that are possible alternatives for "hesp".
 
 e.g.
-- help
-- helm
-- hero
+
+-   help
+-   helm
+-   hero
 
 The resulting list can be accessed as an ArrayList, as the example below:
 
 ```html
-<% if $Results.Spellcheck.Count %>
-    <% loop $Results.Spellcheck %>
-        $word
-    <% end_loop %>
-<% end_if %>
+<% if $Results.Spellcheck.Count %> <% loop $Results.Spellcheck %> $word <%
+end_loop %> <% end_if %>
 ```
 
 ## Collated spellchecking
@@ -37,8 +43,8 @@ Collated spellcheck, is the full term, but spell checked.
 For example searching for "hesp me", the collation would be "help me"
 
 The collated spellcheck results can be displayed like so:
+
 ```html
-<% with $Results %>
-    <% if $getCollatedSpellcheck %>$CollatedSpellcheck<% end_if %>
-<% end_with %>
+<% with $Results %> <% if $getCollatedSpellcheck %>$CollatedSpellcheck<% end_if
+%> <% end_with %>
 ```

--- a/docs/05-Spellcheck.md
+++ b/docs/05-Spellcheck.md
@@ -32,8 +32,11 @@ e.g.
 The resulting list can be accessed as an ArrayList, as the example below:
 
 ```html
-<% if $Results.Spellcheck.Count %> <% loop $Results.Spellcheck %> $word <%
-end_loop %> <% end_if %>
+<% if $Results.Spellcheck.Count %>
+    <% loop $Results.Spellcheck %>
+        $word
+    <%end_loop %>
+<% end_if %>
 ```
 
 ## Collated spellchecking
@@ -45,6 +48,9 @@ For example searching for "hesp me", the collation would be "help me"
 The collated spellcheck results can be displayed like so:
 
 ```html
-<% with $Results %> <% if $getCollatedSpellcheck %>$CollatedSpellcheck<% end_if
-%> <% end_with %>
+<% with $Results %>
+    <% if $getCollatedSpellcheck %>
+        $CollatedSpellcheck
+    <% end_if %>
+<% end_with %>
 ```

--- a/docs/05-Spellcheck.md
+++ b/docs/05-Spellcheck.md
@@ -35,7 +35,7 @@ The resulting list can be accessed as an ArrayList, as the example below:
 <% if $Results.Spellcheck.Count %>
     <% loop $Results.Spellcheck %>
         $word
-    <%end_loop %>
+    <% end_loop %>
 <% end_if %>
 ```
 

--- a/src/Factories/SchemaFactory.php
+++ b/src/Factories/SchemaFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * class SchemaFactory|Firesphere\SolrSearch\Services\SchemaFactory Base service for generating a schema
  *
@@ -155,9 +156,11 @@ class SchemaFactory extends ViewableData
         $fields = $this->index->getCopyFields();
 
         $return = ArrayList::create();
+        $defaultType = SolrCoreService::singleton()->getSolrVersion() === 4 ? 'htmltext' : 'stemfield';
         foreach ($fields as $field => $copyFields) {
             $item = [
                 'Field' => $field,
+                'Type' => (array_key_exists('type', $copyFields) ? $copyFields['type'] : $defaultType)
             ];
 
             $return->push($item);

--- a/src/Factories/SchemaFactory.php
+++ b/src/Factories/SchemaFactory.php
@@ -187,6 +187,8 @@ class SchemaFactory extends ViewableData
             // Allow all fields to be in a copyfield via a shorthand
             if ($fields[0] === '*') {
                 $fields = $this->index->getFulltextFields();
+            } else {
+                unset($fields['type']);
             }
 
             foreach ($fields as $copyField) {

--- a/src/Indexes/BaseIndex.php
+++ b/src/Indexes/BaseIndex.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * class BaseIndex|Firesphere\SolrSearch\Indexes\BaseIndex is the base for indexing items
  *
@@ -101,6 +102,10 @@ abstract class BaseIndex
      * @var bool Signify if a retry should occur if nothing was found and there are suggestions to follow
      */
     private $retry = false;
+    /**
+     * @var bool Include dedicated spellcheck field to remove stemming
+     */
+    private static $include_dedicated_spellcheck_field = true;
 
     /**
      * BaseIndex constructor.


### PR DESCRIPTION
Update the spellcheck copy fields to not use stemming by default. 
Meeting requirements identified in #4. 