### PR TITLE
Feat/sigimm 31  parent indexing

### DIFF
--- a/docs/07-Customisation.md
+++ b/docs/07-Customisation.md
@@ -96,3 +96,21 @@ This includes the `extras` folder in its entirety.
 
 It is easiest to copy the entire `Solr` folder to your own application and alter what you need in there, leaving
 everything else untouched. This will ensure that everything is in place.
+
+## DataObject Parent Reindexing
+
+There are many situations in which an indexed DataObject may be linked to other DataObjects that shouldn't be indexed on their own, but do impact the indexed content of the parent. A very common example of this is Elemental Blocks on a Page - the indexed content of the Page contains the content of the Blocks, and therefore the Page should be updated in the index when the Block is changed.
+
+To implement this behaviour, add the `IndexedParentSolrUpdate` trait to the DataObject along with a `getIndexedParent` function that defines indexed parent. For example:
+
+```php
+class ExampleItem extends DataObject
+{
+    use IndexedParentSolrUpdate;
+
+    public function getIndexedParent()
+    {
+        return $this->owner->getPage();
+    }
+}
+```

--- a/docs/07-Customisation.md
+++ b/docs/07-Customisation.md
@@ -104,7 +104,7 @@ There are many situations in which an indexed DataObject may be linked to other 
 To implement this behaviour, add the `IndexedParentSolrUpdate` trait to the DataObject along with a `getIndexedParent` function that defines indexed parent. For example:
 
 ```php
-class ExampleItem extends DataObject
+class ExampleItem extends BaseElement
 {
     use IndexedParentSolrUpdate;
 

--- a/docs/14-Submodules/05-Elemental.md
+++ b/docs/14-Submodules/05-Elemental.md
@@ -29,3 +29,7 @@ Firesphere\SolrSearch\Indexes\BaseIndex:
 ```
 
 This will index Elements with their Title and rendered content.
+
+## Element Parent Reindexing
+
+Often with Elements, the Element itself is not indexed but the content within the Element is included in its parent Page content. Therefore, when changes are made to the Element, it should trigger a reindex on the parent. Information for implementing this behaviour can be found in [Customisation](../07-Customisation.md#dataobject-parent-reindexing).

--- a/src/Extensions/DataObjectExtension.php
+++ b/src/Extensions/DataObjectExtension.php
@@ -379,22 +379,21 @@ class DataObjectExtension extends DataExtension
     public function doParentReindex($parent)
     {
         $parentHasIndexedParent = $parent->hasMethod('getIndexedParent');
+        $objHasIndexedParent = $this->owner->hasMethod('getIndexedParent');
 
-        if ($parentHasIndexedParent) {
+        if (!$objHasIndexedParent) {
             return;
-        } else {
-            if ($parent) {
-                $service = Injector::inst()->get(SolrCoreService::class);
+        } else if ($parent) {
+            $service = Injector::inst()->get(SolrCoreService::class);
 
-                if ($this->shouldPush() && $service->isValidClass($parent->ClassName)) {
-                    $publishedParent = Versioned::get_by_stage($parent::class, Versioned::LIVE)->byID($parent->ID);
-                    $this->pushToSolr($publishedParent);
-                } else if ($parentHasIndexedParent && $parent->isPublished()) {
-                    $this->doParentReindex($parent->getIndexedParent());
-                }
-
-                $this->doReindex();
+            if ($this->shouldPush() && $service->isValidClass($parent->ClassName)) {
+                $publishedParent = Versioned::get_by_stage($parent::class, Versioned::LIVE)->byID($parent->ID);
+                $this->pushToSolr($publishedParent);
+            } else if ($parentHasIndexedParent && $parent->isPublished()) {
+                $this->doParentReindex($parent->getIndexedParent());
             }
+
+            $this->doReindex();
         }
     }
 }

--- a/src/Extensions/DataObjectExtension.php
+++ b/src/Extensions/DataObjectExtension.php
@@ -378,10 +378,9 @@ class DataObjectExtension extends DataExtension
      */
     public function doParentReindex($parent)
     {
-        $objectTraits = class_uses($this->owner);
-        $indexParentTrait = IndexedParentSolrUpdate::class;
+        $parentHasIndexedParent = $parent->hasMethod('getIndexedParent');
 
-        if (!in_array($indexParentTrait, $objectTraits)) {
+        if ($parentHasIndexedParent) {
             return;
         } else {
             if ($parent) {
@@ -390,7 +389,7 @@ class DataObjectExtension extends DataExtension
                 if ($this->shouldPush() && $service->isValidClass($parent->ClassName)) {
                     $publishedParent = Versioned::get_by_stage($parent::class, Versioned::LIVE)->byID($parent->ID);
                     $this->pushToSolr($publishedParent);
-                } else if ($parent->hasMethod('getIndexedParent') && $parent->isPublished()) {
+                } else if ($parentHasIndexedParent && $parent->isPublished()) {
                     $this->doParentReindex($parent->getIndexedParent());
                 }
 

--- a/src/Traits/IndexedParentSolrUpdate.php
+++ b/src/Traits/IndexedParentSolrUpdate.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Firesphere\SolrSearch\Traits;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Trait for non-indexed data objects that should trigger an indexed parent to update Solr
+ * e.g. elemental blocks on pages
+ *
+ * @package app
+ * @subpackage traits
+ */
+trait IndexedParentSolrUpdate
+{
+    /**
+     * If not versioned, after write, reindex the parent object
+     *
+     * @return void
+     */
+    public function onAfterWrite()
+    {
+        $object = $this instanceof Extension ? $this->owner : $this;
+        if (!$object->hasExtension(Versioned::class) && $parent = $this->getIndexedParent()) {
+            $object->doParentReindex($parent);
+        }
+    }
+
+    /**
+     * If versioned, after publish, reindex the parent object
+     *
+     * @return void
+     */
+    public function onAfterPublish()
+    {
+        if ($parent = $this->getIndexedParent()) {
+            $object = $this instanceof Extension ? $this->owner : $this;
+            $object->doParentReindex($parent);
+        }
+    }
+
+    /**
+     * After delete, reindex the parent object
+     *
+     * @return void
+     */
+    public function onAfterDelete()
+    {
+        if ($parent = $this->getIndexedParent()) {
+            $object = $this instanceof Extension ? $this->owner : $this;
+            $object->doParentReindex($parent);
+        }
+    }
+
+    /**
+     * Get the parent object that is or leads to the object indexed for search
+     *
+     * @return DataObject
+     */
+    abstract public function getIndexedParent();
+}


### PR DESCRIPTION
Add the ability to trigger a reindex on a parent when changes are made to a non-indexed DataObject.
Meeting requirements identified in #10.