### PR TITLE
Replace LRUCache class with CaffeineCache for Solr 9 config

### DIFF
--- a/Solr/9/extras/solrconfig.xml
+++ b/Solr/9/extras/solrconfig.xml
@@ -476,14 +476,8 @@
 
         <!-- Solr Internal Query Caches
 
-             There are two implementations of cache available for Solr,
-             LRUCache, based on a synchronized LinkedHashMap, and
-             FastLRUCache, based on a ConcurrentHashMap.
-
-             FastLRUCache has faster gets and slower puts in single
-             threaded operation and thus is generally faster than LRUCache
-             when the hit ratio of the cache is high (> 75%), and may be
-             faster under other scenarios on multi-cpu systems.
+             There is one implementation of cache available for Solr 9,
+             CaffeieneCache.
         -->
 
         <!-- Filter Cache
@@ -492,20 +486,17 @@
              unordered sets of *all* documents that match a query.  When a
              new searcher is opened, its caches may be prepopulated or
              "autowarmed" using data from caches in the old searcher.
-             autowarmCount is the number of items to prepopulate.  For
-             LRUCache, the autowarmed items will be the most recently
-             accessed items.
+             autowarmCount is the number of items to prepopulate.
 
              Parameters:
-               class - the SolrCache implementation LRUCache or
-                   (LRUCache or FastLRUCache)
+               class - the SolrCache implementation CaffeieneCache
                size - the maximum number of entries in the cache
                initialSize - the initial capacity (number of entries) of
                    the cache.  (see java.util.HashMap)
                autowarmCount - the number of entries to prepopulate from
                    and old cache.
           -->
-        <filterCache class="solr.FastLRUCache"
+        <filterCache class="solr.CaffeineCache"
                      size="512"
                      initialSize="512"
                      autowarmCount="0"/>
@@ -515,7 +506,7 @@
              Caches results of searches - ordered lists of document ids
              (DocList) based on a query, a sort, and the range of documents requested.
           -->
-        <queryResultCache class="solr.LRUCache"
+        <queryResultCache class="solr.CaffeineCache"
                           size="512"
                           initialSize="512"
                           autowarmCount="0"/>
@@ -526,7 +517,7 @@
              document).  Since Lucene internal document ids are transient,
              this cache will not be autowarmed.
           -->
-        <documentCache class="solr.LRUCache"
+        <documentCache class="solr.CaffeineCache"
                        size="512"
                        initialSize="512"
                        autowarmCount="0"/>
@@ -538,7 +529,7 @@
              even if not configured here.
           -->
         <!--
-           <fieldValueCache class="solr.FastLRUCache"
+           <fieldValueCache class="solr.CaffeieneCache"
                             size="512"
                             autowarmCount="128"
                             showItems="32" />
@@ -555,7 +546,7 @@
           -->
         <!--
            <cache name="myUserCache"
-                  class="solr.LRUCache"
+                  class="solr.CaffeieneCache"
                   size="4096"
                   initialSize="1024"
                   autowarmCount="1024"

--- a/Solr/9/extras/solrconfig.xml
+++ b/Solr/9/extras/solrconfig.xml
@@ -477,7 +477,7 @@
         <!-- Solr Internal Query Caches
 
              There is one implementation of cache available for Solr 9,
-             CaffeieneCache.
+             CaffeineCache.
         -->
 
         <!-- Filter Cache
@@ -489,7 +489,7 @@
              autowarmCount is the number of items to prepopulate.
 
              Parameters:
-               class - the SolrCache implementation CaffeieneCache
+               class - the SolrCache implementation CaffeineCache
                size - the maximum number of entries in the cache
                initialSize - the initial capacity (number of entries) of
                    the cache.  (see java.util.HashMap)
@@ -529,7 +529,7 @@
              even if not configured here.
           -->
         <!--
-           <fieldValueCache class="solr.CaffeieneCache"
+           <fieldValueCache class="solr.CaffeineCache"
                             size="512"
                             autowarmCount="128"
                             showItems="32" />
@@ -546,7 +546,7 @@
           -->
         <!--
            <cache name="myUserCache"
-                  class="solr.CaffeieneCache"
+                  class="solr.CaffeineCache"
                   size="4096"
                   initialSize="1024"
                   autowarmCount="1024"


### PR DESCRIPTION
More information contained in issue #12.