### PR TITLE
fix: prevent solr version defaulting to highest available. sigimm-44

### DIFF
--- a/src/Services/SolrCoreService.php
+++ b/src/Services/SolrCoreService.php
@@ -360,7 +360,7 @@ class SolrCoreService
             $serverVersion = $result['lucene']['solr-spec-version'];
             $compare = version_compare($version, $serverVersion);
             if (
-                intval($version) === intval($serverVersion) ||
+                (int)$version === (int)$serverVersion ||
                 $compare === 0 ||
                 $compare === -1
             ) {

--- a/src/Services/SolrCoreService.php
+++ b/src/Services/SolrCoreService.php
@@ -324,10 +324,9 @@ class SolrCoreService
      *       1 means "result version is higher"
      *       0 means "result version is equal"
      *      -1 means "result version is lower"
-     * We want to use the version "higher or equal to", because the
-     * configs are for version X-and-up.
-     * We loop through the versions available from high to low
-     * therefore, if the version is lower, we want to check the next config version
+     * We want to use the version "equal to or less than", 
+     * because there are non-backwards compatible changes in Solr version 9.
+     * We loop through the versions available from high to low.
      *
      * If no valid version is found, throw an error
      *
@@ -354,11 +353,17 @@ class SolrCoreService
         $result = $client->get('solr/admin/info/system?wt=json', $clientOptions);
         $result = json_decode($result->getBody(), 1);
 
+        $lastKey = array_key_last(static::$solr_versions);
+        $lastVersion = static::$solr_versions[$lastKey];
+
         foreach (static::$solr_versions as $version) {
             $compare = version_compare($version, $result['lucene']['solr-spec-version']);
-            if ($compare !== -1) {
+            if ($compare === 0 || $compare === -1) {
                 list($v) = explode('.', $version);
                 return (int)$v;
+            }
+            if ($version === $lastVersion) {
+                return 4;
             }
         }
 

--- a/src/Services/SolrCoreService.php
+++ b/src/Services/SolrCoreService.php
@@ -357,8 +357,13 @@ class SolrCoreService
         $lastVersion = static::$solr_versions[$lastKey];
 
         foreach (static::$solr_versions as $version) {
-            $compare = version_compare($version, $result['lucene']['solr-spec-version']);
-            if ($compare === 0 || $compare === -1) {
+            $serverVersion = $result['lucene']['solr-spec-version'];
+            $compare = version_compare($version, $serverVersion);
+            if (
+                intval($version) === intval($serverVersion) ||
+                $compare === 0 ||
+                $compare === -1
+            ) {
                 list($v) = explode('.', $version);
                 return (int)$v;
             }


### PR DESCRIPTION
Prevent solr version defaulting to the highest available version.
Meeting requirements identified in #14.