### PR TITLE
fix: include prefixed index names in solr log core filtering. sigimm-47

### DIFF
--- a/src/Helpers/SolrLogger.php
+++ b/src/Helpers/SolrLogger.php
@@ -123,7 +123,9 @@ class SolrLogger
         foreach ($validIndexes as $validIndex) {
             /** @var BaseIndex $index */
             $index = Injector::inst()->get($validIndex);
-            array_push($indexNames, $index->getIndexName());
+            $indexName = $index->getIndexName();
+            $indexNamePrefixed = 'x:' . $indexName;
+            array_push($indexNames, $indexName, $indexNamePrefixed);
         }
 
         foreach ($arrayResponse['history']['docs'] as $error) {


### PR DESCRIPTION
This work builds on from https://github.com/signify-nz/silverstripe-solr-search/pull/18. This includes index names prefixed with `x:` as used in solr versions below 9. 