### PR TITLE
Feat/sigimm 45  rebuild jobs

### DIFF
--- a/docs/01-Installation.md
+++ b/docs/01-Installation.md
@@ -33,6 +33,6 @@ class MyIndex extends BaseIndex
 }
 ```
 - Run `vendor/bin/sake dev/tasks/SolrConfigureTask` to configure the core
-- Run `vendor/bin/sake dev/tasks/SolrIndexTask` to add documents to your index
+- Run `vendor/bin/sake dev/tasks/SolrIndexTask` to queue the job to add documents to your index
 
 Once these tasks have completed - happy searching!

--- a/docs/03-Set-up-and-Configuration.md
+++ b/docs/03-Set-up-and-Configuration.md
@@ -219,10 +219,16 @@ The [compatibility module](13-Submodules/01-Fulltext-Search-Compatibility.md) ha
 method that allows you to build your index and then generate the YML content for you. 
 See the compatibility module for more details.
 
-## Grouped indexing
+## Indexing
 
-Be aware that Grouped indexing is `0`-based. Thus, if there are 150 groups to index,
-the final group to index will be 149 instead of 150.
+There are two jobs that can be triggered to perform a reindex: SolrIndexJob and FullSolrIndexJob.
+The only difference between the two is that the FullSolrIndexJob will clear any data from the index before running.
+
+These jobs can be added through the queued jobs admin or through their corresponding Build Task that, when run, will
+queue an instance of the relevant job e.g. running /dev/tasks/SolrIndexTask will queue an instance of the SolrIndexJob.
+
+It is recommended to rely on cron for these tasks to run, however the job queue can be triggered
+manually with Symbiote\QueuedJobs\Tasks\ProcessJobQueueTask.
 
 ## Method output casting
 

--- a/src/Jobs/FullSolrIndexJob.php
+++ b/src/Jobs/FullSolrIndexJob.php
@@ -1,0 +1,389 @@
+<?php
+/**
+ * Class FullSolrIndexJob|Firesphere\SolrSearch\Jobs\SolrIndexTask Index Solr cores
+ *
+ * @package Firesphere\Solr\Search
+ * @author Simon `Firesphere` Erkelens; Marco `Sheepy` Hermo
+ * @copyright Copyright (c) 2018 - now() Firesphere & Sheepy
+ * @author Signify Ltd <info@signify.co.nz>
+ * Signify Ltd modified code in Aug 2024
+ */
+
+namespace Firesphere\SolrSearch\Jobs;
+
+use Exception;
+use Firesphere\SolrSearch\Helpers\SolrLogger;
+use Firesphere\SolrSearch\Indexes\BaseIndex;
+use Firesphere\SolrSearch\Services\SolrCoreService;
+use Psr\Log\LoggerInterface;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataObject;
+use Solarium\Exception\HttpException;
+use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
+
+/**
+ * FullSolrIndexJob is a queued job to index all existing indexes and their classes.
+ *
+ * It always runs on all indexes, to make sure all indexes are up to date.
+ *
+ * It will clear our any existing index data before running.
+ *
+ * @package Firesphere\Solr\Search
+ */
+class FullSolrIndexJob extends AbstractQueuedJob
+{
+    /**
+     * Class info of content to be indexed.
+     * Fits the following structure:
+     * [
+     *      'index' => string,
+     *      'class' => string,
+     *      'group' => int
+     * ]
+     *
+     * @var array
+     */
+    protected $indexableData = [];
+
+    /**
+     * The indexes that need to run.
+     *
+     * @var array
+     */
+    protected $indexes;
+
+    /**
+     * @var BaseIndex Current core being indexed
+     */
+    protected $index;
+
+    /**
+     * Default batch length.
+     *
+     * @var int
+     */
+    protected $batchLength = 250;
+
+    /**
+     * The logger to use
+     *
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * Singleton of {@link SolrCoreService}
+     *
+     * @var SolrCoreService
+     */
+    protected $service;
+
+    /**
+     * Whether the job should clear the index before running.
+     *
+     * @var bool
+     */
+    protected $shouldClearIndex = true;
+
+    /**
+     * My name
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return 'Index groups to Solr search';
+    }
+
+    public function setup()
+    {
+        $this->indexes = (new SolrCoreService())->getValidIndexes();
+        $this->currentStep = 0;
+        $this->isComplete = false;
+        $this->configureIndexableData();
+        $this->addMessage('Calculated ' . $this->totalSteps . ' total steps.');
+        $this->setService(Injector::inst()->get(SolrCoreService::class));
+        if($this->shouldClearIndex) {
+            $this->clearIndexes();
+        }
+    }
+
+    /**
+     * Process this job
+     *
+     * @return self
+     * @throws Exception
+     * @throws HTTPException
+     */
+    public function process()
+    {
+        $this->currentStep++;
+
+        $data = array_pop($this->indexableData);
+        if (!$this->index instanceof $data['index']) {
+            $this->setIndex(Injector::inst()->get($data['index']));
+        };
+        $this->indexStateClass($data['index'], $data['class'], $data['group']);
+
+        if ($this->currentStep >= $this->totalSteps) {
+            $this->isComplete = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Clear the given index if a full re-index is needed
+     *
+     * @throws Exception
+     */
+    public function clearIndexes()
+    {
+        $service = $this->getService();
+        foreach($this->indexes as $index) {
+            $service->doManipulate(ArrayList::create([]), SolrCoreService::DELETE_TYPE_ALL, Injector::inst()->get($index));
+        }
+    }
+
+    /**
+     * Index a group of a class for a specific state and index
+     *
+     * @param string $group Group to index
+     * @param string $class Class to index
+     * @throws Exception
+     */
+    private function indexStateClass(string $index, string $class, string $group): void
+    {
+        // Generate filtered list of local records
+        $baseClass = DataObject::getSchema()->baseDataClass($class);
+        /** @var DataList|DataObject[] $items */
+        $items = DataObject::get($baseClass);
+        if (!empty($classes = Config::inst()->get($index, 'exclude_classes'))) {
+            $items = $items->exclude(['ClassName' => $classes]);
+        }
+        $items = $items->sort('ID ASC')
+            ->limit($this->getBatchLength(), ($group * $this->getBatchLength()));
+        if ($items->count()) {
+            $this->updateIndex($items);
+        }
+    }
+
+    /**
+     * Execute the update on the client
+     *
+     * @param SS_List $items Items to index
+     * @throws Exception
+     */
+    protected function updateIndex($items): void
+    {
+        $index = $this->getIndex();
+        $client = $index->getClient();
+        $update = $client->createUpdate();
+        $service = $this->getService();
+        $service->setDebug(true);
+        try {
+            $service->updateIndex($index, $items, $update);
+            $client->update($update);
+        } catch (Exception $error) {
+            $this->logException($index->getIndexName(), $error);
+        }
+    }
+
+    /**
+     * Set up array of indexable data and set total number of steps.
+     *
+     * @return void
+     */
+    protected function configureIndexableData()
+    {
+        $steps = 0;
+        $indexes = $this->indexes;
+        foreach ($indexes as $index) {
+            $indexInstance = Injector::inst()->get($index);
+            $batchLength = $this->getBatchLength();
+            foreach ($indexInstance->getClasses() as $class) {
+                $batchesCount = $this->getBatchesCount($index, $class, $batchLength);
+                $steps += $batchesCount;
+                for ($n = 0; $n < $batchesCount; $n++) {
+                    $this->indexableData[] = ['index' => $index, 'class' => $class, 'group' => $n];
+                }
+            }
+        }
+        $this->totalSteps = $steps;
+    }
+
+    /**
+     * Calculate the number of batches that should be indexed for given class / index.
+     *
+     * @param  string $index
+     * @param  string $class
+     * @param  int $batchLength
+     * @return int
+     */
+    protected function getBatchesCount(string $index, string $class, int $batchLength)
+    {
+        // Generate filtered list of local records
+        $baseClass = DataObject::getSchema()->baseDataClass($class);
+        /** @var DataList|DataObject[] $items */
+        $items = DataObject::get($baseClass);
+        if (!empty($classes = Config::inst()->get($index, 'exclude_classes'))) {
+            $items = $items->exclude(['ClassName' => $classes]);
+        }
+        $this->addMessage($baseClass . ' has ' . $items->count() . ' items. Batch length is ' . $batchLength);
+        $batches = $items->count() / $batchLength;
+        $this->addMessage('Adding ' . ceil($batches) . ' batches.');
+        return ceil($batches);
+    }
+
+    /**
+     * Log an exception if it happens. Most are catched, these logs are for the developers
+     * to identify problems and fix them.
+     *
+     * @codeCoverageIgnore This is actually tested through reflection
+     * @param string $index Index that is currently running
+     * @param int $group Group currently attempted to index
+     * @param Exception $exception Exception that's been thrown
+     * @throws HTTPException
+     * @throws ValidationException
+     */
+    private function logException($index, Exception $exception): void
+    {
+        $msg = sprintf(
+            'Error indexing core %s,' . PHP_EOL .
+            'Please log in to the CMS to find out more about Indexing errors' . PHP_EOL,
+            $index
+        );
+        $this->getLogger()->error($exception->getMessage());
+        $this->getLogger()->error($msg);
+        SolrLogger::logMessage('ERROR', $msg);
+    }
+
+    /**
+     * Get array of data to index
+     *
+     * @return array
+     */
+    public function getIndexableData(): array
+    {
+        return $this->indexableData;
+    }
+
+    /**
+     * Set array of data to index
+     *
+     * @param array $classToIndex
+     * @return FullSolrIndexJob
+     */
+    public function setIndexableData($indexableData)
+    {
+        $this->indexableData = $indexableData;
+
+        return $this;
+    }
+
+    /**
+     * Get the indexes
+     *
+     * @return array
+     */
+    public function getIndexes(): array
+    {
+        return $this->indexes;
+    }
+
+    /**
+     * Set the indexes if needed
+     *
+     * @param array $indexes
+     */
+    public function setIndexes($indexes)
+    {
+        $this->indexes = $indexes;
+    }
+
+    /**
+     * Get the length of a single batch
+     *
+     * @return int
+     */
+    public function getBatchLength(): int
+    {
+        return $this->batchLength;
+    }
+
+    /**
+     * Set the length of a single batch
+     *
+     * @param int $batchLength
+     */
+    public function setBatchLength(int $batchLength): void
+    {
+        $this->batchLength = $batchLength;
+    }
+
+    /**
+     * Get an instance of SolrCoreService
+     *
+     * @return SolrCoreService
+     */
+    public function getService(): SolrCoreService
+    {
+        return $this->service;
+    }
+
+    /**
+     * Set an instance of SolrCoreService
+     *
+     * @param SolrCoreService $batchLength
+     */
+    public function setService($service): void
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * Get the logger
+     *
+     * @return LoggerInterface
+     */
+    public function getLogger()
+    {
+        if (!$this->logger) {
+            $this->logger = Injector::inst()->get(LoggerInterface::class);
+        }
+
+        return $this->logger;
+    }
+
+    /**
+     * Set the logger if needed
+     *
+     * @param LoggerInterface $logger
+     */
+    public function setLogger($logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Get an instance of the current index class.
+     *
+     * @return BaseIndex
+     */
+    public function getIndex(): BaseIndex
+    {
+        return $this->index;
+    }
+
+    /**
+     * Set an instance of the current index class
+     *
+     * @param BaseIndex $index
+     */
+    public function setIndex(BaseIndex $index): void
+    {
+        $this->index = $index;
+    }
+}

--- a/src/Jobs/FullSolrIndexJob.php
+++ b/src/Jobs/FullSolrIndexJob.php
@@ -28,7 +28,7 @@ use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
  *
  * It always runs on all indexes, to make sure all indexes are up to date.
  *
- * It will clear our any existing index data before running.
+ * It will clear out any existing index data before running.
  *
  * @package Firesphere\Solr\Search
  */
@@ -55,7 +55,9 @@ class FullSolrIndexJob extends AbstractQueuedJob
     protected $indexes;
 
     /**
-     * @var BaseIndex Current core being indexed
+     * Current core being indexed
+     *
+     * @var BaseIndex
      */
     protected $index;
 
@@ -88,7 +90,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
     protected $shouldClearIndex = true;
 
     /**
-     * My name
+     * Gets a title for the job that can be used in listings
      *
      * @return string
      */
@@ -97,6 +99,9 @@ class FullSolrIndexJob extends AbstractQueuedJob
         return 'Index groups to Solr search';
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setup()
     {
         $this->indexes = (new SolrCoreService())->getValidIndexes();
@@ -151,6 +156,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
     /**
      * Index a group of a class for a specific state and index
      *
+     * @param string $index Name of index
      * @param string $group Group to index
      * @param string $class Class to index
      * @throws Exception
@@ -244,7 +250,6 @@ class FullSolrIndexJob extends AbstractQueuedJob
      *
      * @codeCoverageIgnore This is actually tested through reflection
      * @param string $index Index that is currently running
-     * @param int $group Group currently attempted to index
      * @param Exception $exception Exception that's been thrown
      * @throws HTTPException
      * @throws ValidationException
@@ -274,7 +279,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
     /**
      * Set array of data to index
      *
-     * @param array $classToIndex
+     * @param array $indexableData
      * @return FullSolrIndexJob
      */
     public function setIndexableData($indexableData)
@@ -337,7 +342,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
     /**
      * Set an instance of SolrCoreService
      *
-     * @param SolrCoreService $batchLength
+     * @param SolrCoreService $service
      */
     public function setService($service): void
     {

--- a/src/Jobs/FullSolrIndexJob.php
+++ b/src/Jobs/FullSolrIndexJob.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class FullSolrIndexJob|Firesphere\SolrSearch\Jobs\SolrIndexTask Index Solr cores
+ * Class FullSolrIndexJob|Firesphere\SolrSearch\Jobs\FullSolrIndexJob Index Solr cores
  *
  * @package Firesphere\Solr\Search
  * @author Simon `Firesphere` Erkelens; Marco `Sheepy` Hermo
@@ -19,7 +19,9 @@ use Psr\Log\LoggerInterface;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\SS_List;
 use Solarium\Exception\HttpException;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 
@@ -160,6 +162,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
      * @param string $group Group to index
      * @param string $class Class to index
      * @throws Exception
+     * @return void
      */
     private function indexStateClass(string $index, string $class, string $group): void
     {
@@ -182,6 +185,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
      *
      * @param SS_List $items Items to index
      * @throws Exception
+     * @return void
      */
     protected function updateIndex($items): void
     {
@@ -203,7 +207,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
      *
      * @return void
      */
-    protected function configureIndexableData()
+    protected function configureIndexableData(): void
     {
         $steps = 0;
         $indexes = $this->indexes;
@@ -253,6 +257,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
      * @param Exception $exception Exception that's been thrown
      * @throws HTTPException
      * @throws ValidationException
+     * @return void
      */
     private function logException($index, Exception $exception): void
     {
@@ -323,6 +328,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
      * Set the length of a single batch
      *
      * @param int $batchLength
+     * @return void
      */
     public function setBatchLength(int $batchLength): void
     {
@@ -343,6 +349,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
      * Set an instance of SolrCoreService
      *
      * @param SolrCoreService $service
+     * @return void
      */
     public function setService($service): void
     {
@@ -367,6 +374,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
      * Set the logger if needed
      *
      * @param LoggerInterface $logger
+     * @return void
      */
     public function setLogger($logger): void
     {
@@ -387,6 +395,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
      * Set an instance of the current index class
      *
      * @param BaseIndex $index
+     * @return void
      */
     public function setIndex(BaseIndex $index): void
     {

--- a/src/Jobs/FullSolrIndexJob.php
+++ b/src/Jobs/FullSolrIndexJob.php
@@ -103,7 +103,8 @@ class FullSolrIndexJob extends AbstractQueuedJob
         $this->currentStep = 0;
         $this->isComplete = false;
         $this->configureIndexableData();
-        $this->addMessage('Calculated ' . $this->totalSteps . ' total steps.');
+        $this->addMessage('Calculated ' . $this->totalSteps . ' total batches to index.');
+        $this->getLogger()->info('Calculated ' . $this->totalSteps . ' total batches to index.');
         $this->setService(Injector::inst()->get(SolrCoreService::class));
         if($this->shouldClearIndex) {
             $this->clearIndexes();
@@ -231,9 +232,9 @@ class FullSolrIndexJob extends AbstractQueuedJob
         if (!empty($classes = Config::inst()->get($index, 'exclude_classes'))) {
             $items = $items->exclude(['ClassName' => $classes]);
         }
-        $this->addMessage($baseClass . ' has ' . $items->count() . ' items. Batch length is ' . $batchLength);
         $batches = $items->count() / $batchLength;
-        $this->addMessage('Adding ' . ceil($batches) . ' batches.');
+        $this->addMessage('Adding ' . ceil($batches) . ' batches of ' . $class . ' to index.');
+        $this->getLogger()->info('Adding ' . ceil($batches) . ' batches of ' . $class . ' to index.');
         return ceil($batches);
     }
 

--- a/src/Jobs/FullSolrIndexJob.php
+++ b/src/Jobs/FullSolrIndexJob.php
@@ -66,7 +66,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
      *
      * @var int
      */
-    protected $batchLength = 250;
+    protected $batchLength = 500;
 
     /**
      * The logger to use

--- a/src/Jobs/FullSolrIndexJob.php
+++ b/src/Jobs/FullSolrIndexJob.php
@@ -98,7 +98,7 @@ class FullSolrIndexJob extends AbstractQueuedJob
      */
     public function getTitle()
     {
-        return 'Index groups to Solr search';
+        return 'Clear and rebuild Solr index';
     }
 
     /**

--- a/src/Jobs/SolrConfigureJob.php
+++ b/src/Jobs/SolrConfigureJob.php
@@ -11,12 +11,11 @@ namespace Firesphere\SolrSearch\Jobs;
 
 use Firesphere\SolrSearch\Tasks\SolrConfigureTask;
 use Psr\SimpleCache\InvalidArgumentException;
-use ReflectionException;
 use SilverStripe\Control\NullHTTPRequest;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\ValidationException;
-use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Solarium\Exception\HttpException;
+use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 
 /**
  * Class SolrConfigureJob
@@ -46,7 +45,7 @@ class SolrConfigureJob extends AbstractQueuedJob
      * @throws ValidationException
      * @throws InvalidArgumentException
      */
-    public function process()
+    public function process(): void
     {
         /** @var SolrConfigureTask $task */
         $task = Injector::inst()->get(SolrConfigureTask::class);

--- a/src/Jobs/SolrIndexJob.php
+++ b/src/Jobs/SolrIndexJob.php
@@ -16,7 +16,7 @@ namespace Firesphere\SolrSearch\Jobs;
  *
  * It always runs on all indexes, to make sure all indexes are up to date.
  *
- * It will not clear our any existing index data before running.
+ * It will not clear out any existing index data before running.
  *
  * @package Firesphere\Solr\Search
  */

--- a/src/Jobs/SolrIndexJob.php
+++ b/src/Jobs/SolrIndexJob.php
@@ -5,215 +5,27 @@
  * @package Firesphere\Solr\Search
  * @author Simon `Firesphere` Erkelens; Marco `Sheepy` Hermo
  * @copyright Copyright (c) 2018 - now() Firesphere & Sheepy
+ * @author Signify Ltd <info@signify.co.nz>
+ * Signify Ltd modified code in June 2025
  */
 
 namespace Firesphere\SolrSearch\Jobs;
 
-use Exception;
-use Firesphere\SolrSearch\Services\SolrCoreService;
-use Firesphere\SolrSearch\Tasks\SolrIndexTask;
-use ReflectionException;
-use SilverStripe\Control\Director;
-use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Core\Injector\Injector;
-use stdClass;
-use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
-use Symbiote\QueuedJobs\Services\QueuedJobService;
-use Solarium\Exception\HttpException;
-
 /**
- * Class SolrIndexJob is a queued job to index all existing indexes and their classes.
+ * FullSolrIndexJob is a queued job to index all existing indexes and their classes.
  *
  * It always runs on all indexes, to make sure all indexes are up to date.
  *
+ * It will not clear our any existing index data before running.
+ *
  * @package Firesphere\Solr\Search
  */
-class SolrIndexJob extends AbstractQueuedJob
+class SolrIndexJob extends FullSolrIndexJob
 {
-
     /**
-     * The class that should be indexed.
-     * If set, the task should run the given class with the given group
-     * The class should be popped off the array at the end of each subset
-     * so the next class becomes the class to index.
+     * Whether the job should clear the index before running.
      *
-     * Rinse and repeat for each class in the index, until this array is empty
-     *
-     * @var array
+     * @var bool
      */
-    protected $classToIndex = [];
-    /**
-     * The indexes that need to run.
-     *
-     * @var array
-     */
-    protected $indexes;
-
-    /**
-     * My name
-     *
-     * @return string
-     */
-    public function getTitle()
-    {
-        return 'Index groups to Solr search';
-    }
-
-    /**
-     * Process this job
-     *
-     * @return self
-     * @throws Exception
-     * @throws HTTPException
-     */
-    public function process()
-    {
-        $data = $this->jobData;
-
-        $this->configureRun($data);
-
-        $this->currentStep = $this->currentStep ?: 0;
-        $index = Injector::inst()->get($this->indexes[0]);
-        $this->classToIndex = count($this->classToIndex) ? $this->classToIndex : $index->getClasses();
-        $indexArgs = [
-            'group' => $this->currentStep,
-            'index' => $this->indexes[0],
-            'class' => $this->classToIndex[0],
-        ];
-        /** @var SolrIndexTask $task */
-        $task = Injector::inst()->get(SolrIndexTask::class);
-        $request = new HTTPRequest(
-            'GET',
-            '/dev/tasks/SolrIndexTask',
-            $indexArgs
-        );
-
-        $result = $task->run($request);
-        $this->totalSteps = $result;
-        // If the result is false, the job should fail too
-        // Thus, only set to true if the result isn't false :)
-        $this->isComplete = true;
-
-        return $this;
-    }
-
-    /**
-     * Configure the run for the valid indexes
-     *
-     * @param stdClass|null $data
-     */
-    protected function configureRun($data)
-    {
-        // If null gets passed in, it goes a bit wonky with the check for indexes
-        if (!$data) {
-            $data = new stdClass();
-            $data->indexes = null;
-        }
-        if (!isset($data->indexes) || !count($data->indexes)) { // If indexes are set, don't load them.
-            $this->indexes = (new SolrCoreService())->getValidIndexes();
-        } else {
-            $this->setIndexes($data->indexes);
-            $this->setClassToIndex($data->classToIndex);
-        }
-    }
-
-    /**
-     * Set up the next job if needed
-     */
-    public function afterComplete()
-    {
-        [$currentStep, $totalSteps] = $this->getNextSteps();
-        // If there are no indexes left to run, let's call it a day
-        if (count($this->indexes)) {
-            $nextJob = new self();
-            $jobData = new stdClass();
-
-            $jobData->classToIndex = $this->getClassToIndex();
-            $jobData->indexes = $this->getIndexes();
-            $nextJob->setJobData($totalSteps, $currentStep, false, $jobData, []);
-
-            // Add a wee break to let the system recover from this heavy operation
-            Injector::inst()->get(QueuedJobService::class)
-                ->queueJob($nextJob, date('Y-m-d H:i:00', strtotime('+1 minutes')));
-        }
-        parent::afterComplete();
-    }
-
-    /**
-     * Get the next step to execute
-     *
-     * @return array
-     */
-    protected function getNextSteps(): array
-    {
-        $cores = SolrCoreService::config()->get('cpucores') ?: 1;
-        // Force a single count for when the job is not run from CLI
-        if (!Director::is_cli()) {
-            $cores = 1;
-        }
-        $currentStep = $this->currentStep + $cores; // Add the amount of cores
-        $totalSteps = $this->totalSteps;
-        // No more steps to execute on this class, let's go to the next class
-        if ($currentStep >= $totalSteps) {
-            array_shift($this->classToIndex);
-            // Reset the current step, a complete new set of data is coming
-            $currentStep = 0;
-            $totalSteps = 1;
-        }
-        // If there are no classes left in this index, go to the next index
-        if (!count($this->classToIndex)) {
-            array_shift($this->indexes);
-            // Reset the current step, a complete new set of data is coming
-            $currentStep = 0;
-            $totalSteps = 1;
-        }
-
-        return [$currentStep, $totalSteps];
-    }
-
-    /**
-     * Which Indexes should I index
-     *
-     * @return array
-     */
-    public function getClassToIndex(): array
-    {
-        return $this->classToIndex;
-    }
-
-    /**
-     * Which classes should I index
-     *
-     * @param array $classToIndex
-     * @return SolrIndexJob
-     */
-    public function setClassToIndex($classToIndex)
-    {
-        $this->classToIndex = $classToIndex;
-
-        return $this;
-    }
-
-    /**
-     * Get the indexes
-     *
-     * @return array
-     */
-    public function getIndexes(): array
-    {
-        return $this->indexes;
-    }
-
-    /**
-     * Set the indexes if needed
-     *
-     * @param array $indexes
-     * @return SolrIndexJob
-     */
-    public function setIndexes($indexes)
-    {
-        $this->indexes = $indexes;
-
-        return $this;
-    }
+    protected $shouldClearIndex = false;
 }

--- a/src/Jobs/SolrIndexJob.php
+++ b/src/Jobs/SolrIndexJob.php
@@ -28,4 +28,14 @@ class SolrIndexJob extends FullSolrIndexJob
      * @var bool
      */
     protected $shouldClearIndex = false;
+
+    /**
+     * Gets a title for the job that can be used in listings
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return 'Rebuild Solr index';
+    }
 }

--- a/src/Tasks/FullSolrIndexTask.php
+++ b/src/Tasks/FullSolrIndexTask.php
@@ -4,6 +4,7 @@ use Firesphere\SolrSearch\Jobs\FullSolrIndexJob;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
+use SilverStripe\Dev\TaskRunner;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 class FullSolrIndexTask extends BuildTask

--- a/src/Tasks/FullSolrIndexTask.php
+++ b/src/Tasks/FullSolrIndexTask.php
@@ -1,0 +1,43 @@
+<?php
+
+use Firesphere\SolrSearch\Jobs\FullSolrIndexJob;
+use SilverStripe\Control\Director;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\BuildTask;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+
+class FullSolrIndexTask extends BuildTask
+{
+    /**
+     * URLSegment of this task
+     *
+     * @var string
+     */
+    private static $segment = 'FullSolrIndexTask';
+    /**
+     * @var string $title
+     * Shown in the overview on the {@link TaskRunner}
+     * HTML or CLI interface. Should be short and concise, no HTML allowed.
+     */
+    protected $title = 'Full Solr Index update';
+    /**
+     * @var string $description Describe the implications the task has,
+     * and the changes it makes. Accepts HTML formatting.
+     */
+    protected $description = 'Add or update documents to an existing Solr core. Clears any existing data from index first.';
+
+    /**
+     *  {@inheritDoc}
+     */
+    public function run($request)
+    {
+        $queuedJobService = Injector::inst()->get(QueuedJobService::class);
+        $solrIndexJob = Injector::inst()->create(FullSolrIndexJob::class);
+
+        $id = $queuedJobService->queueJob($solrIndexJob);
+        echo ("Solr Index Job added to job queue with ID: " . $id . "\n");
+        if (!Director::is_cli()) {
+            echo("Visit <a href=\"/admin/queuedjobs\">queued jobs admin</a> to see job status \n");
+        }
+    }
+}

--- a/src/Tasks/SolrIndexTask.php
+++ b/src/Tasks/SolrIndexTask.php
@@ -15,6 +15,7 @@ use Firesphere\SolrSearch\Jobs\SolrIndexJob;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
+use SilverStripe\Dev\TaskRunner;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 /**

--- a/src/Tasks/SolrIndexTask.php
+++ b/src/Tasks/SolrIndexTask.php
@@ -11,29 +11,11 @@
 
 namespace Firesphere\SolrSearch\Tasks;
 
-use Exception;
-use Firesphere\SolrSearch\Factories\DocumentFactory;
-use Firesphere\SolrSearch\Helpers\SolrLogger;
-use Firesphere\SolrSearch\Indexes\BaseIndex;
-use Firesphere\SolrSearch\Services\SolrCoreService;
-use Firesphere\SolrSearch\States\SiteState;
-use Firesphere\SolrSearch\Traits\LoggerTrait;
-use Firesphere\SolrSearch\Traits\SolrIndexTrait;
-use Psr\Log\LoggerInterface;
-use ReflectionException;
-use SilverStripe\Control\Controller;
+use Firesphere\SolrSearch\Jobs\SolrIndexJob;
 use SilverStripe\Control\Director;
-use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
-use SilverStripe\ORM\ArrayList;
-use SilverStripe\ORM\DataList;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\DB;
-use SilverStripe\ORM\SS_List;
-use SilverStripe\ORM\ValidationException;
-use SilverStripe\Versioned\Versioned;
-use Solarium\Exception\HttpException;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 /**
  * Class SolrIndexTask
@@ -43,9 +25,6 @@ use Solarium\Exception\HttpException;
  */
 class SolrIndexTask extends BuildTask
 {
-    use LoggerTrait;
-    use SolrIndexTrait;
-
     /**
      * URLSegment of this task
      *
@@ -53,400 +32,30 @@ class SolrIndexTask extends BuildTask
      */
     private static $segment = 'SolrIndexTask';
     /**
-     * Store the current states for all instances of SiteState
-     *
-     * @var array
-     */
-    public $currentStates;
-    /**
-     * My name
-     *
-     * @var string
+     * @var string $title
+     * Shown in the overview on the {@link TaskRunner}
+     * HTML or CLI interface. Should be short and concise, no HTML allowed.
      */
     protected $title = 'Solr Index update';
     /**
-     * What do I do?
+     * @var string $description Describe the implications the task has,
+     * and the changes it makes. Accepts HTML formatting.
      *
-     * @var string
      */
     protected $description = 'Add or update documents to an existing Solr core.';
 
     /**
-     * SolrIndexTask constructor. Sets up the document factory
-     *
-     * @throws ReflectionException
-     */
-    public function __construct()
-    {
-        parent::__construct();
-        // Only index live items.
-        // The old FTS module also indexed Draft items. This is unnecessary
-        // If versioned is needed, a separate Versioned Search module is required
-        Versioned::set_reading_mode(Versioned::DEFAULT_MODE);
-        $this->setService(Injector::inst()->get(SolrCoreService::class));
-        $this->setLogger(Injector::inst()->get(LoggerInterface::class));
-        $this->setDebug(Director::isDev() || Director::is_cli());
-        $this->setBatchLength(DocumentFactory::config()->get('batchLength'));
-        $cores = SolrCoreService::config()->get('cpucores') ?: 1;
-        $this->setCores($cores);
-        $currentStates = SiteState::currentStates();
-        SiteState::setDefaultStates($currentStates);
-    }
-
-    /**
-     * Implement this method in the task subclass to
-     * execute via the TaskRunner
-     *
-     * @param HTTPRequest $request Current request
-     * @return int|bool
-     * @throws Exception
-     * @throws HTTPException
+     *  {@inheritDoc}
      */
     public function run($request)
     {
-        $start = time();
-        $this->getLogger()->info(date('Y-m-d H:i:s'));
-        [$vars, $group, $isGroup] = $this->taskSetup($request);
-        $groups = 0;
-        $indexes = $this->service->getValidIndexes($request->getVar('index'));
+        $queuedJobService = Injector::inst()->get(QueuedJobService::class);
+        $solrIndexJob = Injector::inst()->create(SolrIndexJob::class);
 
-        foreach ($indexes as $indexName) {
-            /** @var BaseIndex $index */
-            $index = Injector::inst()->get($indexName, false);
-            $this->setIndex($index);
-
-            $indexClasses = $this->index->getClasses();
-            $classes = $this->getClasses($vars, $indexClasses);
-            if (!count($classes)) {
-                continue;
-            }
-
-            $this->clearIndex($vars);
-
-            $groups = $this->indexClassForIndex($classes, $isGroup, $group);
+        $id = $queuedJobService->queueJob($solrIndexJob);
+        echo ("Solr Index Job added to job queue with ID: " . $id . "\n");
+        if (!Director::is_cli()) {
+            echo("Visit <a href=\"/admin/queuedjobs\">queued jobs admin</a> to see job status \n");
         }
-
-        $this->getLogger()->info(gmdate('Y-m-d H:i:s'));
-        $time = gmdate('H:i:s', (time() - $start));
-        $this->getLogger()->info(sprintf('Time taken: %s', $time));
-
-        return $groups;
-    }
-
-    /**
-     * Set up the requirements for this task
-     *
-     * @param HTTPRequest $request Current request
-     * @return array
-     */
-    protected function taskSetup(HTTPRequest $request): array
-    {
-        $vars = $request->getVars();
-        $debug = $this->isDebug() || isset($vars['debug']);
-        // Forcefully set the debugging to whatever the outcome of the above is
-        $this->setDebug($debug, true);
-        $group = $vars['group'] ?? 0;
-        $start = $vars['start'] ?? 0;
-        $group = ($start > $group) ? $start : $group;
-        $isGroup = isset($vars['group']);
-
-        return [$vars, $group, $isGroup];
-    }
-
-    /**
-     * get the classes to run for this task execution
-     *
-     * @param array $vars URL GET Parameters
-     * @param array $classes Classes to index
-     * @return bool|array
-     */
-    protected function getClasses(array $vars, array $classes): array
-    {
-        if (isset($vars['class'])) {
-            return array_intersect($classes, [$vars['class']]);
-        }
-
-        return $classes;
-    }
-
-    /**
-     * Clear the given index if a full re-index is needed
-     *
-     * @param array $vars URL GET Parameters
-     * @throws Exception
-     */
-    public function clearIndex(array $vars)
-    {
-        if (!empty($vars['clear'])) {
-            $this->getLogger()->info(sprintf('Clearing index %s', $this->index->getIndexName()));
-            $this->service->doManipulate(ArrayList::create([]), SolrCoreService::DELETE_TYPE_ALL, $this->index);
-        }
-    }
-
-    /**
-     * Index the classes for a specific index
-     *
-     * @param array $classes Classes that need indexing
-     * @param bool $isGroup Indexing a specific group?
-     * @param int $group Group to index
-     * @return int|bool
-     * @throws Exception
-     * @throws HTTPException
-     */
-    protected function indexClassForIndex(array $classes, bool $isGroup, int $group)
-    {
-        $groups = 0;
-        foreach ($classes as $class) {
-            $groups = $this->indexClass($isGroup, $class, $group);
-        }
-
-        return $groups;
-    }
-
-    /**
-     * Index a single class for a given index. {@link static::indexClassForIndex()}
-     *
-     * @param bool $isGroup Is a specific group indexed
-     * @param string $class Class to index
-     * @param int $group Group to index
-     * @return int|bool
-     * @throws HTTPException
-     * @throws ValidationException
-     */
-    private function indexClass(bool $isGroup, string $class, int $group)
-    {
-        $this->getLogger()->info(sprintf('Indexing %s for %s', $class, $this->getIndex()->getIndexName()));
-        [$totalGroups, $groups] = $this->getGroupSettings($isGroup, $class, $group);
-        $this->getLogger()->info(sprintf('Total groups %s', $totalGroups));
-        do {
-            try {
-                if ($this->hasPCNTL()) {
-                    // @codeCoverageIgnoreStart
-                    $group = $this->spawnChildren($class, $group, $groups);
-                    // @codeCoverageIgnoreEnd
-                } else {
-                    $this->doReindex($group, $class);
-                }
-                $group++;
-            } catch (Exception $error) {
-                // @codeCoverageIgnoreStart
-                $this->logException($this->index->getIndexName(), $group, $error);
-                continue;
-                // @codeCoverageIgnoreEnd
-            }
-        } while ($group <= $groups);
-
-        return $totalGroups;
-    }
-
-    /**
-     * Check the amount of groups and the total against the isGroup check.
-     *
-     * @param bool $isGroup Is it a specific group
-     * @param string $class Class to check
-     * @param int $group Current group to index
-     * @return array
-     */
-    private function getGroupSettings(bool $isGroup, string $class, int $group): array
-    {
-        $totalGroups = (int)ceil($class::get()->count() / $this->getBatchLength());
-        $groups = $isGroup ? ($group + $this->getCores() - 1) : $totalGroups;
-
-        return [$totalGroups, $groups];
-    }
-
-    /**
-     * Check if PCNTL is available and/or useable.
-     * The unittest param is from phpunit.xml.dist, meant to bypass the exit(0) call
-     * The pcntl parameter check is for unit tests, but PHPUnit does not support PCNTL (yet)
-     *
-     * @return bool
-     */
-    private function hasPCNTL(): bool
-    {
-        return Director::is_cli() &&
-            function_exists('pcntl_fork') &&
-            (Controller::curr()->getRequest()->getVar('unittest') === 'pcntl' ||
-                !Controller::curr()->getRequest()->getVar('unittest'));
-    }
-
-    /**
-     * For each core, spawn a child process that will handle a separate group.
-     * This speeds up indexing through CLI massively.
-     *
-     * @codeCoverageIgnore Can't be tested because PCNTL is not available
-     * @param string $class Class to index
-     * @param int $group Group to index
-     * @param int $groups Total amount of groups
-     * @return int Last group indexed
-     * @throws Exception
-     * @throws HTTPException
-     */
-    private function spawnChildren(string $class, int $group, int $groups): int
-    {
-        $start = $group;
-        $pids = [];
-        $cores = $this->getCores();
-        // for each core, start a grouped indexing
-        for ($i = 0; $i < $cores; $i++) {
-            $start = $group + $i;
-            if ($start < $groups) {
-                $this->runForkedChild($class, $pids, $start);
-            }
-        }
-        // Wait for each child to finish
-        // It needs to wait for them independently,
-        // or it runs out of memory for some reason
-        foreach ($pids as $pid) {
-            pcntl_waitpid($pid, $status);
-        }
-        $commit = $this->index->getClient()->createUpdate();
-        $commit->addCommit();
-
-        $this->index->getClient()->update($commit);
-
-        return $start;
-    }
-
-    /**
-     * Create a fork and run the child
-     *
-     * @codeCoverageIgnore Can't be tested because PCNTL is not available
-     * @param string $class Class to index
-     * @param array $pids Array of all the child Process IDs
-     * @param int $start Start point for the objects
-     * @return void
-     * @throws HTTPException
-     * @throws ValidationException
-     */
-    private function runForkedChild(string $class, array &$pids, int $start): void
-    {
-        $pid = pcntl_fork();
-        // PID needs to be pushed before anything else, for some reason
-        $pids[] = $pid;
-        $config = DB::getConfig();
-        DB::connect($config);
-        $this->runChild($class, $pid, $start);
-    }
-
-    /**
-     * Ren a single child index operation
-     *
-     * @codeCoverageIgnore Can't be tested because PCNTL is not available
-     * @param string $class Class to index
-     * @param int $pid PID of the child
-     * @param int $start Position to start
-     * @throws HTTPException
-     * @throws ValidationException
-     * @throws Exception
-     */
-    private function runChild(string $class, int $pid, int $start): void
-    {
-        if ($pid !== 0) {
-            return;
-        }
-        try {
-            $this->doReindex($start, $class, $pid);
-        } catch (Exception $error) {
-            SolrLogger::logMessage('ERROR', $error);
-            $msg = sprintf(
-                'Something went wrong while indexing %s on %s, see the logs for details',
-                $start,
-                $this->index->getIndexName()
-            );
-            throw new Exception($msg);
-        }
-    }
-
-    /**
-     * Reindex the given group, for each state
-     *
-     * @param int $group Group to index
-     * @param string $class Class to index
-     * @param bool|int $pid Are we a child process or not
-     * @throws Exception
-     */
-    private function doReindex(int $group, string $class, $pid = false)
-    {
-        $start = time();
-        $states = SiteState::getStates();
-        foreach ($states as $state) {
-            if ($state !== SiteState::DEFAULT_STATE && !empty($state)) {
-                SiteState::withState($state);
-            }
-            $this->indexStateClass($group, $class);
-        }
-
-        SiteState::withState(SiteState::DEFAULT_STATE);
-        $end = gmdate('i:s', time() - $start);
-        $this->getLogger()->info(sprintf('Indexed group %s in %s', $group, $end));
-
-        // @codeCoverageIgnoreStart
-        if ($pid !== false) {
-            exit(0);
-        }
-        // @codeCoverageIgnoreEnd
-    }
-
-    /**
-     * Index a group of a class for a specific state and index
-     *
-     * @param string $group Group to index
-     * @param string $class Class to index
-     * @throws Exception
-     */
-    private function indexStateClass(string $group, string $class): void
-    {
-        // Generate filtered list of local records
-        $baseClass = DataObject::getSchema()->baseDataClass($class);
-        /** @var DataList|DataObject[] $items */
-        $items = DataObject::get($baseClass);
-        if (!empty($classes = $this->getIndex()->config()->get('exclude_classes'))) {
-            $items = $items->exclude(['ClassName' => $classes]);
-        }
-        $items = $items->sort('ID ASC')
-            ->limit($this->getBatchLength(), ($group * $this->getBatchLength()));
-        if ($items->count()) {
-            $this->updateIndex($items);
-        }
-    }
-
-    /**
-     * Execute the update on the client
-     *
-     * @param SS_List $items Items to index
-     * @throws Exception
-     */
-    private function updateIndex($items): void
-    {
-        $index = $this->getIndex();
-        $client = $index->getClient();
-        $update = $client->createUpdate();
-        $this->service->setDebug($this->debug);
-        $this->service->updateIndex($index, $items, $update);
-        $client->update($update);
-    }
-
-    /**
-     * Log an exception if it happens. Most are catched, these logs are for the developers
-     * to identify problems and fix them.
-     *
-     * @codeCoverageIgnore This is actually tested through reflection
-     * @param string $index Index that is currently running
-     * @param int $group Group currently attempted to index
-     * @param Exception $exception Exception that's been thrown
-     * @throws HTTPException
-     * @throws ValidationException
-     */
-    private function logException($index, int $group, Exception $exception): void
-    {
-        $this->getLogger()->error($exception->getMessage());
-        $msg = sprintf(
-            'Error indexing core %s on group %s,' . PHP_EOL .
-            'Please log in to the CMS to find out more about Indexing errors' . PHP_EOL,
-            $index,
-            $group
-        );
-        SolrLogger::logMessage('ERROR', $msg);
     }
 }


### PR DESCRIPTION
Rebuild the solr index job to be more stable.
This has mostly involved porting the functionality of the existing index task into a queued job and leveraging the steps feature of queued jobs.
Have added two variants of this task, one of which will clear existing data from the solr index before running.
I have left the existing task in place, as i'm not sure yet whether we wish to keep it or remove it in favour of the index job. For the moment at least, I think it will helpful for testing to run them both in one environment and compare.

See #7 for further info.