### PR TITLE
fix: ensure that parent hooks are called if IndexedRelationSolrUpdate is not applied to an extension

### DIFF
--- a/src/Traits/IndexedRelationsSolrUpdate.php
+++ b/src/Traits/IndexedRelationsSolrUpdate.php
@@ -28,6 +28,10 @@ trait IndexedRelationsSolrUpdate
      */
     public function onAfterWrite(): void
     {
+        if (!$this instanceof Extension)
+        {
+            parent::onAfterWrite();
+        };
         /** @var DataObject $sourceObject */
         $sourceObject = $this instanceof Extension ? $this->owner : $this;
         $relatedObjects = $this->getIndexedRelations() ?? null;
@@ -44,6 +48,10 @@ trait IndexedRelationsSolrUpdate
      */
     public function onBeforeDelete(): void
     {
+        if (!$this instanceof Extension)
+        {
+            parent::onBeforeDelete();
+        };
         $relatedObjects = $this->getIndexedRelations();
         $this->relations = $relatedObjects->toArray();
     }
@@ -55,6 +63,10 @@ trait IndexedRelationsSolrUpdate
      */
     public function onAfterDelete(): void
     {
+        if (!$this instanceof Extension)
+        {
+            parent::onAfterDelete();
+        };
         /** @var DataObject $sourceObject */
         $sourceObject = $this instanceof Extension ? $this->owner : $this;
         $relatedObjects = $this->relations ?? null;


### PR DESCRIPTION
Ensure that parent hooks are called if IndexedRelationSolrUpdate trait is not applied to an extension.