### PR TITLE
Configurable error deletion for 2.x branch

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,6 @@
+---
+Name: SolrConfig
+---
+
+Firesphere\SolrSearch\Models\SolrLog:
+  deletion_period: false # Should be parsable by php's strtotime() function e.g. -1 week. False value will delete all logs.

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,4 +3,4 @@ Name: SolrConfig
 ---
 
 Firesphere\SolrSearch\Models\SolrLog:
-  deletion_period: false # Should be parsable by php's strtotime() function e.g. -1 week. False value will delete all logs.
+  deletion_period: 10 # the number of days after which logs will be deleted. A null/false value will prevent log deletion, 0 will delete all logs.

--- a/docs/09-Debugging.md
+++ b/docs/09-Debugging.md
@@ -26,7 +26,14 @@ The logs can be found at the URL `/admin/searchadmin/Firesphere-SolrSearch-Model
 
 As an admin, you can truncate the log database via the dev task `dev/tasks/SolrClearErrorsTask`.
 
-Use this with caution though, as it will completely wipe the errors logged and no data will remain at all.
+This will run automatically at the beginning of every reindex. The number of days after which logs are deleted is a configurable value, see config.yml.
+
+Consider running this task through the CLI, as it may take some time (especially if it has not been run before).
+
+```yaml
+Firesphere\SolrSearch\Models\SolrLog:
+  deletion_period: 10
+```
 
 It is strongly advised to only clear out the logs if they have all been reviewed and you are sure nothing serious is wrong.
 

--- a/src/Models/SolrLog.php
+++ b/src/Models/SolrLog.php
@@ -9,6 +9,8 @@
 
 namespace Firesphere\SolrSearch\Models;
 
+use DateInterval;
+use DateTime;
 use Psr\Log\LoggerInterface;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Config;
@@ -193,31 +195,41 @@ class SolrLog extends DataObject implements PermissionProvider
         ];
     }
 
+
     /**
      * Delete logs older than a configurable date.
      *
-     * @return void
+     * @return int The number of logs deleted.
      */
-    public static function deleteLogs()
+    public static function truncateLogs()
     {
         $tableName = DataObject::getSchema()->tableName(self::class);
-        $deletion_schedule = Config::inst()->get(self::class, 'deletion_period') ?? 'now';
+        $deletionSchedule = Config::inst()->get(self::class, 'deletion_period');
+        $logger = Injector::inst()->get(LoggerInterface::class);
 
-        Injector::inst()->get(LoggerInterface::class)->info(_t(
-            __class__ . ".CLEARLOG",
-            "Emptying logs for table " . $tableName . PHP_EOL
+        if (!is_int($deletionSchedule) || $deletionSchedule < 0) {
+            $logger->info('The value of "deletion_period" is invalid, must be an integer >= 0 to trigger log truncation.');
+            return 0;
+        };
+
+        $deleteDate = (new DateTime())->sub(DateInterval::createFromDateString("{$deletionSchedule} days"))->format(DateTime::ATOM);
+
+        $logger->info(_t(
+            __class__ . '.CLEARLOG',
+            'Emptying logs for table ' . $tableName . PHP_EOL
         ));
 
-        $deleteDate = date('Y-m-d H:i:s', strtotime($deletion_schedule));
+
         $logs = SolrLog::get()->filter(['Created:LessThan' => $deleteDate]);
         $count = $logs->count();
         if ($count) {
-            echo('Deleting ' . $count . ' logs from the database.');
+            $logger->info('Deleting ' . $count . ' logs from the database.');
             $query = SQLDelete::create([$tableName]);
             $query->addWhere(['Created < ?' => $deleteDate]);
             $query->execute();
         } else {
-            echo('No logs were found older than the deletion date.');
+            $logger->info('No logs were found older than the deletion date.');
         }
+        return $count;
     }
 }

--- a/src/Models/SolrLog.php
+++ b/src/Models/SolrLog.php
@@ -9,9 +9,13 @@
 
 namespace Firesphere\SolrSearch\Models;
 
+use Psr\Log\LoggerInterface;
 use SilverStripe\Control\Director;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\ORM\Queries\SQLDelete;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
@@ -187,5 +191,33 @@ class SolrLog extends DataObject implements PermissionProvider
                 ),
             ],
         ];
+    }
+
+    /**
+     * Delete logs older than a configurable date.
+     *
+     * @return void
+     */
+    public static function deleteLogs()
+    {
+        $tableName = DataObject::getSchema()->tableName(self::class);
+        $deletion_schedule = Config::inst()->get(self::class, 'deletion_period') ?? 'now';
+
+        Injector::inst()->get(LoggerInterface::class)->info(_t(
+            __class__ . ".CLEARLOG",
+            "Emptying logs for table " . $tableName . PHP_EOL
+        ));
+
+        $deleteDate = date('Y-m-d H:i:s', strtotime($deletion_schedule));
+        $logs = SolrLog::get()->filter(['Created:LessThan' => $deleteDate]);
+        $count = $logs->count();
+        if ($count) {
+            echo('Deleting ' . $count . ' logs from the database.');
+            $query = SQLDelete::create([$tableName]);
+            $query->addWhere(['Created < ?' => $deleteDate]);
+            $query->execute();
+        } else {
+            echo('No logs were found older than the deletion date.');
+        }
     }
 }

--- a/src/Tasks/ClearErrorsTask.php
+++ b/src/Tasks/ClearErrorsTask.php
@@ -10,6 +10,7 @@
 
 namespace Firesphere\SolrSearch\Tasks;
 
+use Firesphere\SolrSearch\Models\SolrLog;
 use Psr\Log\LoggerInterface;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
@@ -38,15 +39,11 @@ class ClearErrorsTask extends BuildTask
     protected $description = 'Remove all errors in the database that are related to Solr indexing/configuring etc.';
 
     /**
-     * Run the truncate of the SolrLog table
+     * Delete entries from the SolrLog table
      * @inheritDoc
      */
     public function run($request)
     {
-        Injector::inst()->get(LoggerInterface::class)->warning(_t(
-            __class__ . ".CLEARLOG",
-            "Emptying logs for table SolrLog." . PHP_EOL . "WARNING: Any logs that are not inspected will be gone soon."
-        ));
-        DB::query('TRUNCATE TABLE `Solr_SolrLog`');
+        SolrLog::deleteLogs();
     }
 }

--- a/src/Tasks/ClearErrorsTask.php
+++ b/src/Tasks/ClearErrorsTask.php
@@ -44,6 +44,6 @@ class ClearErrorsTask extends BuildTask
      */
     public function run($request)
     {
-        SolrLog::deleteLogs();
+        SolrLog::truncateLogs();
     }
 }

--- a/src/Tasks/SolrIndexTask.php
+++ b/src/Tasks/SolrIndexTask.php
@@ -13,6 +13,7 @@ use Exception;
 use Firesphere\SolrSearch\Factories\DocumentFactory;
 use Firesphere\SolrSearch\Helpers\SolrLogger;
 use Firesphere\SolrSearch\Indexes\BaseIndex;
+use Firesphere\SolrSearch\Models\SolrLog;
 use Firesphere\SolrSearch\Services\SolrCoreService;
 use Firesphere\SolrSearch\States\SiteState;
 use Firesphere\SolrSearch\Traits\LoggerTrait;
@@ -104,6 +105,10 @@ class SolrIndexTask extends BuildTask
     {
         $start = time();
         $this->getLogger()->info(date('Y-m-d H:i:s'));
+
+        SolrLog::deleteLogs();
+        $this->getLogger()->info('Clearing logs from DB.');
+
         [$vars, $group, $isGroup] = $this->taskSetup($request);
         $groups = 0;
         $indexes = $this->service->getValidIndexes($request->getVar('index'));

--- a/src/Tasks/SolrIndexTask.php
+++ b/src/Tasks/SolrIndexTask.php
@@ -106,8 +106,8 @@ class SolrIndexTask extends BuildTask
         $start = time();
         $this->getLogger()->info(date('Y-m-d H:i:s'));
 
-        SolrLog::deleteLogs();
-        $this->getLogger()->info('Clearing logs from DB.');
+        $logsDeleted = SolrLog::truncateLogs();
+        $this->getLogger()->info('Clearing ' . $logsDeleted . ' logs from DB.');
 
         [$vars, $group, $isGroup] = $this->taskSetup($request);
         $groups = 0;


### PR DESCRIPTION
This is a duplicate of #35 for the 2.x branch, the only notable difference is that we call SolrLog::deleteLogs() in SolrIndexTask rather than FullSolrIndexJob (which doesn't exist in this version)